### PR TITLE
refactor: use dashmap instead of mutex<hashmap>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,6 +382,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "clap",
+ "dashmap",
  "hex",
  "indexmap",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ edition = "2021"
 anyhow = "1.0.59"                                    # error handling
 bytes = "1.3.0"                                      # helps manage buffers
 clap = { version = "=4.1.0", features = ["derive"] } # creating a cli
+dashmap = "5.5.3"
 hex = "0.4.3"
 indexmap = "2.2.6"
 rand = "0.8.5"


### PR DESCRIPTION
- `keys` command no longer works since dashmap doesn't support that, we can live with this since dashmap works better in all other cases.
- some simplifications in the db code